### PR TITLE
feat(caller)!: added funcs `ForceCallByName` and `ForceCallWitherByName`

### DIFF
--- a/caller/caller.go
+++ b/caller/caller.go
@@ -131,7 +131,7 @@ func CallByName(object any, method string, args []any, convertArgs bool) (_ []an
 }
 
 /*
-ForceCallByName is extended version of [CallByName].
+ForceCallByName is an extended version of [CallByName].
 
 The following code cannot work:
 
@@ -139,7 +139,7 @@ The following code cannot work:
 	caller.CallByName(&p, "SetName", []any{"Jane"}, false)
 
 because `&p` returns a pointer to an interface, not to the `person` type.
-The same problem exists without using that package:
+The same problem occurs without using that package:
 
 	var tmp any = person{}
 	p := &tmp.(person)

--- a/caller/caller.go
+++ b/caller/caller.go
@@ -48,6 +48,7 @@ func Call(fn any, args []any, convertArgs bool) (_ []any, err error) {
 CallProvider works similar to [Call] with the difference it requires a provider as the first argument.
 Provider is a function which returns 1 or 2 values.
 The second return value which is optional must be a type of error.
+See [ProviderError].
 
 	p := func() (any, error) {
 	    db, err := sql.Open("mysql", "user:password@/dbname")
@@ -65,8 +66,9 @@ The second return value which is optional must be a type of error.
 	mysql, err := CallProvider(p)
 */
 func CallProvider(provider any, args []any, convertArgs bool) (_ any, err error) {
+	executedProvider := false
 	defer func() {
-		if err != nil {
+		if !executedProvider && err != nil {
 			err = grouperror.Prefix(fmt.Sprintf("cannot call provider %T: ", provider), err)
 		}
 	}()
@@ -81,11 +83,16 @@ func CallProvider(provider any, args []any, convertArgs bool) (_ any, err error)
 		return nil, err
 	}
 
+	executedProvider = true
+
 	r := results[0]
 	var e error
 	if len(results) > 1 {
 		// do not panic when results[1] == nil
 		e, _ = results[1].(error)
+	}
+	if e != nil {
+		e = newProviderError(e) // TODO decorate?
 	}
 
 	return r, e
@@ -124,6 +131,35 @@ func CallByName(object any, method string, args []any, convertArgs bool) (_ []an
 }
 
 /*
+ForceCallByName is extended version of [CallByName].
+
+The following code cannot work:
+
+	var p any = person{}
+	caller.CallByName(&p, "SetName", []any{"Jane"}, false)
+
+because `&p` returns a pointer to an interface, not to the `person` type.
+The same problem exists without using that package:
+
+	var tmp any = person{}
+	p := &tmp.(person)
+	// compiler returns:
+	// invalid operation: cannot take address of tmp.(person) (comma, ok expression of type person).
+
+[ForceCallByName] solves that problem by copying the value and creating a pointer to it using the [reflect] package,
+but that solution is slightly slower. In contrast to [CallByName], it requires a pointer always.
+*/
+func ForceCallByName(object any, method string, args []any, convertArgs bool) (_ []any, err error) {
+	defer func() {
+		if err != nil {
+			err = grouperror.Prefix(fmt.Sprintf("cannot call method (%T).%+q: ", object, method), err)
+		}
+	}()
+
+	return caller.ValidateAndForceCallByName(object, method, args, convertArgs, caller.DontValidate)
+}
+
+/*
 CallWitherByName works similar to [CallByName] with the difference the method must be a wither.
 
 	type Person struct {
@@ -148,15 +184,30 @@ func CallWitherByName(object any, wither string, args []any, convertArgs bool) (
 		}
 	}()
 
-	fn, err := caller.Wither(object, wither)
+	fn, err := caller.Method(object, wither)
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := caller.CallFunc(fn, args, convertArgs)
-	var v any
-	if len(r) > 0 {
-		v = r[0]
+	r, err := caller.ValidateAndCallFunc(fn, args, convertArgs, caller.ValidateWither)
+	if err != nil {
+		return nil, err
 	}
-	return v, err
+	return r[0], nil
+}
+
+// ForceCallWitherByName calls the given wither (see [CallWitherByName]) using the same approach as [ForceCallByName].
+func ForceCallWitherByName(object any, wither string, args []any, convertArgs bool) (_ any, err error) {
+	defer func() {
+		if err != nil {
+			err = grouperror.Prefix(fmt.Sprintf("cannot call wither (%T).%+q: ", object, wither), err)
+		}
+	}()
+
+	r, err := caller.ValidateAndForceCallByName(object, wither, args, convertArgs, caller.ValidateWither)
+	if err != nil {
+		return nil, err
+	}
+
+	return r[0], nil
 }

--- a/caller/caller.go
+++ b/caller/caller.go
@@ -92,7 +92,7 @@ func CallProvider(provider any, args []any, convertArgs bool) (_ any, err error)
 		e, _ = results[1].(error)
 	}
 	if e != nil {
-		e = newProviderError(e) // TODO decorate?
+		e = newProviderError(grouperror.Prefix("provider returned error: ", e))
 	}
 
 	return r, e

--- a/caller/caller_test.go
+++ b/caller/caller_test.go
@@ -274,7 +274,7 @@ func TestCallProvider(t *testing.T) {
 			return nil, &myError{errors.New("my error")}
 		}
 		_, err := caller.CallProvider(p, nil, false)
-		assert.EqualError(t, err, "my error")
+		assert.EqualError(t, err, "provider returned error: my error")
 		assert.IsType(t, (*caller.ProviderError)(nil), err)
 
 		var providerErr *caller.ProviderError
@@ -310,7 +310,7 @@ func TestCallProvider(t *testing.T) {
 				provider: func() (any, error) {
 					return nil, errors.New("test error")
 				},
-				err: "test error",
+				err: "provider returned error: test error",
 			},
 			{
 				provider: func() any {

--- a/caller/caller_test.go
+++ b/caller/caller_test.go
@@ -493,6 +493,10 @@ func (p *person) SetName(n string) {
 	p.name = n
 }
 
+func (p *person) Empty() person {
+	return person{}
+}
+
 type nums []int
 
 func (n *nums) Append(v int) {
@@ -517,6 +521,14 @@ func TestEnforcedCall(t *testing.T) {
 				assert.Nil(t, r)
 			}
 			assert.Equal(t, nums{5, 6, 7}, n.(nums))
+		})
+		t.Run("OK #3 (nil pointer)", func(t *testing.T) {
+			var p1 *person
+			var p2 any = p1
+			r, err := caller.ForceCallByName(&p2, "Empty", nil, false)
+			assert.NoError(t, err)
+			assert.Nil(t, p1)
+			assert.Equal(t, person{}, r[0])
 		})
 	})
 	t.Run("Errors", func(t *testing.T) {

--- a/caller/caller_test.go
+++ b/caller/caller_test.go
@@ -574,13 +574,21 @@ func (p *Pet) NameType() (name, type_ string) {
 }
 
 func TestForceCallWitherByName(t *testing.T) {
-	t.Run("OK", func(t *testing.T) {
+	t.Run("OK #1", func(t *testing.T) {
 		var p any = Pet{}
 		r, err := caller.ForceCallWitherByName(&p, "WithName", []any{"Laika"}, false)
 		assert.NoError(t, err)
 		r, err = caller.ForceCallWitherByName(&r, "WithType", []any{"dog"}, false)
 		assert.NoError(t, err)
 		assert.Equal(t, Pet{Name: "Laika", Type: "dog"}, *r.(*Pet))
+	})
+	t.Run("OK #2 (nil pointer)", func(t *testing.T) {
+		var p1 *person
+		var p2 any = p1
+		r, err := caller.ForceCallWitherByName(&p2, "Empty", nil, false)
+		assert.NoError(t, err)
+		assert.Nil(t, p1)
+		assert.Equal(t, person{}, r)
 	})
 	t.Run("Error", func(t *testing.T) {
 		var p any = Pet{}

--- a/caller/caller_test.go
+++ b/caller/caller_test.go
@@ -461,7 +461,7 @@ func TestCallWitherByName(t *testing.T) {
 		assert.Nil(t, r)
 	})
 
-	t.Run("Nil pointer", func(t *testing.T) {
+	t.Run("Nil pointer receiver", func(t *testing.T) {
 		var p *person
 		r, err := caller.CallWitherByName(p, "Empty", nil, false)
 		assert.NoError(t, err)
@@ -530,7 +530,7 @@ func TestEnforcedCall(t *testing.T) {
 			}
 			assert.Equal(t, nums{5, 6, 7}, n.(nums))
 		})
-		t.Run("OK #3 (nil pointer)", func(t *testing.T) {
+		t.Run("OK #3 (nil pointer receiver)", func(t *testing.T) {
 			var p1 *person
 			var p2 any = p1
 			r, err := caller.ForceCallByName(&p2, "Empty", nil, false)
@@ -590,7 +590,7 @@ func TestForceCallWitherByName(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, Pet{Name: "Laika", Type: "dog"}, *r.(*Pet))
 	})
-	t.Run("OK #2 (nil pointer)", func(t *testing.T) {
+	t.Run("OK #2 (nil pointer receiver)", func(t *testing.T) {
 		var p1 *person
 		var p2 any = p1
 		r, err := caller.ForceCallWitherByName(&p2, "Empty", nil, false)

--- a/caller/caller_test.go
+++ b/caller/caller_test.go
@@ -460,6 +460,14 @@ func TestCallWitherByName(t *testing.T) {
 		assert.EqualError(t, err, `cannot call wither (*interface {})."method": unexpected pointer loop`)
 		assert.Nil(t, r)
 	})
+
+	t.Run("Nil pointer", func(t *testing.T) {
+		var p *person
+		r, err := caller.CallWitherByName(p, "Empty", nil, false)
+		assert.NoError(t, err)
+		assert.Nil(t, p)
+		assert.Equal(t, person{}, r)
+	})
 }
 
 type ints []int

--- a/caller/constraints_test.go
+++ b/caller/constraints_test.go
@@ -65,7 +65,7 @@ func TestConstraint(t *testing.T) {
 	// v := book{}; CallByName(v, ...
 	// var v interface{} = book{}; CallByName(&v, ...
 	t.Run("Call a method", func(t *testing.T) {
-		t.Run("A pointer receiver", func(t *testing.T) {
+		t.Run("Pointer receiver", func(t *testing.T) {
 			t.Run("Given errors", func(t *testing.T) {
 				t.Run("v := book{}; CallByName(v, ...", func(t *testing.T) {
 					b := book{}
@@ -75,11 +75,20 @@ func TestConstraint(t *testing.T) {
 					assert.Zero(t, b)
 				})
 				t.Run("var v any = book{}; CallByName(&v, ...", func(t *testing.T) {
-					var b any = book{}
-					r, err := caller.CallByName(&b, "SetTitle", []any{harryPotterTitle}, false)
-					assert.EqualError(t, err, `cannot call method (*interface {})."SetTitle": invalid func (*interface {})."SetTitle"`)
-					assert.Nil(t, r)
-					assert.Equal(t, emptyBook, b)
+					t.Run("CallByName", func(t *testing.T) {
+						var b any = book{}
+						r, err := caller.CallByName(&b, "SetTitle", []any{harryPotterTitle}, false)
+						assert.EqualError(t, err, `cannot call method (*interface {})."SetTitle": invalid func (*interface {})."SetTitle"`)
+						assert.Nil(t, r)
+						assert.Equal(t, emptyBook, b)
+					})
+					t.Run("ForceCallByName", func(t *testing.T) {
+						var b any = book{}
+						r, err := caller.ForceCallByName(&b, "SetTitle", []any{harryPotterTitle}, false)
+						assert.NoError(t, err)
+						assert.Nil(t, r)
+						assert.Equal(t, harryPotter, b)
+					})
 				})
 			})
 			t.Run("Given scenarios", func(t *testing.T) {
@@ -128,7 +137,7 @@ func TestConstraint(t *testing.T) {
 			})
 		})
 		// Methods with a value receiver do not have any constraints
-		t.Run("A value receiver", func(t *testing.T) {
+		t.Run("Value receiver", func(t *testing.T) {
 			t.Run("b := book{}", func(t *testing.T) {
 				b := book{}
 				r, err := caller.CallWitherByName(b, "WithTitle", []any{harryPotterTitle}, false)
@@ -158,10 +167,17 @@ func TestConstraint(t *testing.T) {
 				assert.Equal(t, &emptyBook, b)
 			})
 		})
-		t.Run("An unexported method", func(t *testing.T) {
-			b := book{}
-			_, err := caller.CallByName(&b, "setTitle", []any{harryPotter}, false)
-			assert.EqualError(t, err, `cannot call method (*caller_test.book)."setTitle": invalid func (*caller_test.book)."setTitle"`)
+		t.Run("Unexported method", func(t *testing.T) {
+			t.Run("CallByName", func(t *testing.T) {
+				b := book{}
+				_, err := caller.CallByName(&b, "setTitle", []any{harryPotter}, false)
+				assert.EqualError(t, err, `cannot call method (*caller_test.book)."setTitle": invalid func (*caller_test.book)."setTitle"`)
+			})
+			t.Run("ForceCallByName", func(t *testing.T) {
+				b := book{}
+				_, err := caller.ForceCallByName(&b, "setTitle", []any{harryPotter}, false)
+				assert.EqualError(t, err, `cannot call method (*caller_test.book)."setTitle": invalid func (*caller_test.book)."setTitle"`)
+			})
 		})
 	})
 }

--- a/caller/errors.go
+++ b/caller/errors.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2023 Bartłomiej Krukowski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package caller
+
+import (
+	"github.com/gontainer/gontainer-helpers/v2/grouperror"
+)
+
+/*
+ProviderError wraps errors returned by providers in [CallProvider].
+
+	type myError struct {
+		error
+	}
+
+	p := func() (any, error) {
+		return nil, &myError{errors.New("my error")}
+	}
+
+	_, err := caller.CallProvider(p, nil, false)
+	if err != nil {
+		var providerErr *caller.ProviderError
+		if errors.As(err, &providerErr) {
+			fmt.Println("provider returned error:", providerErr)
+		} else {
+			fmt.Println("provider wasn't invoked:", err)
+		}
+	}
+*/
+type ProviderError struct {
+	error
+}
+
+func newProviderError(err error) *ProviderError {
+	return &ProviderError{error: err}
+}
+
+func (e *ProviderError) Collection() []error {
+	return grouperror.Collection(e.error)
+}
+
+func (e *ProviderError) Unwrap() error {
+	return e.error
+}

--- a/caller/internal/caller/call.go
+++ b/caller/internal/caller/call.go
@@ -110,6 +110,7 @@ func ValidateAndForceCallByName(object any, method string, args []any, convertAr
 		return nil, err
 	}
 
+	// see [intReflect.Set]
 	for {
 		switch {
 		case chain.Prefixed(reflect.Ptr, reflect.Ptr):

--- a/caller/internal/caller/call.go
+++ b/caller/internal/caller/call.go
@@ -135,10 +135,6 @@ func ValidateAndForceCallByName(object any, method string, args []any, convertAr
 	}
 
 	if len(chain) == 3 && chain.Prefixed(reflect.Ptr, reflect.Interface) {
-		tmp := val.Elem().Elem()
-		if !tmp.IsValid() {
-			return nil, errors.New("nil value")
-		}
 		cp := reflect.New(val.Elem().Elem().Type())
 		cp.Elem().Set(val.Elem().Elem())
 

--- a/caller/internal/caller/call.go
+++ b/caller/internal/caller/call.go
@@ -60,7 +60,7 @@ func ValidateAndCallFunc(fn reflect.Value, args []any, convertArgs bool, v FuncV
 // CallFunc calls the given func.
 //
 // fn.Kind() MUST BE equal to [reflect.Func]
-func CallFunc(fn reflect.Value, args []any, convertArgs bool) (res []any, _ error) {
+func CallFunc(fn reflect.Value, args []any, convertArgs bool) ([]any, error) {
 	fnType := reflectType{fn.Type()}
 
 	if len(args) > fnType.NumIn() && !fnType.IsVariadic() {

--- a/container/README.md
+++ b/container/README.md
@@ -369,8 +369,8 @@ func (p *Person) SetName(n string) {
 
 func main() {
 	s := container.NewService()
-	s.SetConstructor(func () *Person {
-		return &Person{} // it must be a pointer, because `SetName` requires a pointer receiver
+	s.SetConstructor(func() Person {
+		return Person{}
 	})
 	s.AppendCall("SetName", container.NewDependencyValue("Jane"))
 
@@ -379,7 +379,7 @@ func main() {
 
 	jane, _ := c.Get("jane")
 	fmt.Printf("%+v\n", jane)
-	// Output: &{Name:Jane}
+	// Output: {Name:Jane}
 }
 ```
 </details>

--- a/container/container_params_test.go
+++ b/container/container_params_test.go
@@ -64,7 +64,7 @@ func TestContainer_GetParam(t *testing.T) {
 		}))
 
 		v, err := c.GetParam("env")
-		assert.EqualError(t, err, `getParam("env"): cannot call provider func() (interface {}, error): could not read env variable`)
+		assert.EqualError(t, err, `getParam("env"): could not read env variable`)
 		assert.Nil(t, v)
 	})
 

--- a/container/container_params_test.go
+++ b/container/container_params_test.go
@@ -64,7 +64,7 @@ func TestContainer_GetParam(t *testing.T) {
 		}))
 
 		v, err := c.GetParam("env")
-		assert.EqualError(t, err, `getParam("env"): could not read env variable`)
+		assert.EqualError(t, err, `getParam("env"): provider returned error: could not read env variable`)
 		assert.Nil(t, v)
 	})
 

--- a/container/container_services.go
+++ b/container/container_services.go
@@ -246,7 +246,7 @@ func (c *Container) executeServiceCalls(
 		}
 
 		if call.wither {
-			result, err = caller.CallWitherByName(result, call.method, params, convertArgs)
+			result, err = caller.ForceCallWitherByName(&result, call.method, params, convertArgs)
 			if err != nil {
 				errs[i] = grouperror.Prefix(fmt.Sprintf("%s %+q: ", action, call.method), err)
 				// wither may return a nil value for error,
@@ -254,7 +254,7 @@ func (c *Container) executeServiceCalls(
 				break
 			}
 		} else {
-			_, err = caller.CallByName(&result, call.method, params, convertArgs)
+			_, err = caller.ForceCallByName(&result, call.method, params, convertArgs)
 			errs[i] = grouperror.Prefix(fmt.Sprintf("%s %+q: ", action, call.method), err)
 		}
 	}

--- a/container/container_services_test.go
+++ b/container/container_services_test.go
@@ -96,7 +96,7 @@ func TestContainer_executeServiceCalls(t *testing.T) {
 		c.OverrideService("service", s)
 
 		expected := []string{
-			`get("service"): resolve args "SetName": arg #0: could not fetch the name from the config`,
+			`get("service"): resolve args "SetName": arg #0: provider returned error: could not fetch the name from the config`,
 			`get("service"): call "SetAge": cannot call method (*interface {})."SetAge": invalid func (*struct {})."SetAge"`,
 			`get("service"): call "SetColor": cannot call method (*interface {})."SetColor": invalid func (*struct {})."SetColor"`,
 			`get("service"): wither "WithLogger": cannot call wither (*interface {})."WithLogger": invalid func (*struct {})."WithLogger"`,
@@ -119,7 +119,7 @@ func TestContainer_createNewService(t *testing.T) {
 		c.OverrideService("service", s)
 		service, err := c.Get("service")
 		assert.Nil(t, service)
-		assert.EqualError(t, err, `get("service"): constructor: could not create`)
+		assert.EqualError(t, err, `get("service"): constructor: provider returned error: could not create`)
 	})
 	t.Run("Errors in args", func(t *testing.T) {
 		s := container.NewService()
@@ -137,8 +137,8 @@ func TestContainer_createNewService(t *testing.T) {
 		c.OverrideService("server", s)
 
 		expected := []string{
-			`get("server"): constructor args: arg #0: unexpected error 1`,
-			`get("server"): constructor args: arg #1: unexpected error 2`,
+			`get("server"): constructor args: arg #0: provider returned error: unexpected error 1`,
+			`get("server"): constructor args: arg #1: provider returned error: unexpected error 2`,
 		}
 
 		svc, err := c.Get("server")
@@ -179,7 +179,7 @@ func TestContainer_setServiceFields(t *testing.T) {
 
 		expected := []string{
 			`get("service"): set field "Name": set (*interface {})."Name": field "Name" does not exist`,
-			`get("service"): field value "Age": unexpected error`,
+			`get("service"): field value "Age": provider returned error: unexpected error`,
 		}
 
 		svc, err := c.Get("service")
@@ -223,7 +223,7 @@ func TestContainer_Get_doNotCacheOnError(t *testing.T) {
 			ctx = container.ContextWithContainer(ctx, c)
 
 			five, err := c.GetInContext(ctx, "five")
-			assert.EqualError(t, err, `get("five"): constructor: my error`)
+			assert.EqualError(t, err, `get("five"): constructor: provider returned error: my error`)
 			assert.Nil(t, five)
 
 			// second invocation does not return error
@@ -326,7 +326,7 @@ func TestContainer_Get_errorInDecorator(t *testing.T) {
 	)
 
 	_, err := c.Get("service")
-	assert.EqualError(t, err, `get("service"): decorator #0: my error`)
+	assert.EqualError(t, err, `get("service"): decorator #0: provider returned error: my error`)
 }
 
 type Server struct {

--- a/container/container_services_test.go
+++ b/container/container_services_test.go
@@ -96,10 +96,10 @@ func TestContainer_executeServiceCalls(t *testing.T) {
 		c.OverrideService("service", s)
 
 		expected := []string{
-			`get("service"): resolve args "SetName": arg #0: cannot call provider func() (interface {}, error): could not fetch the name from the config`,
-			`get("service"): call "SetAge": cannot call method (*interface {})."SetAge": invalid func (*interface {})."SetAge"`,
-			`get("service"): call "SetColor": cannot call method (*interface {})."SetColor": invalid func (*interface {})."SetColor"`,
-			`get("service"): wither "WithLogger": cannot call wither (struct {})."WithLogger": invalid func (struct {})."WithLogger"`,
+			`get("service"): resolve args "SetName": arg #0: could not fetch the name from the config`,
+			`get("service"): call "SetAge": cannot call method (*interface {})."SetAge": invalid func (*struct {})."SetAge"`,
+			`get("service"): call "SetColor": cannot call method (*interface {})."SetColor": invalid func (*struct {})."SetColor"`,
+			`get("service"): wither "WithLogger": cannot call wither (*interface {})."WithLogger": invalid func (*struct {})."WithLogger"`,
 		}
 
 		svc, err := c.Get("service")
@@ -119,17 +119,17 @@ func TestContainer_createNewService(t *testing.T) {
 		c.OverrideService("service", s)
 		service, err := c.Get("service")
 		assert.Nil(t, service)
-		assert.EqualError(t, err, `get("service"): constructor: cannot call provider func() (interface {}, error): could not create`)
+		assert.EqualError(t, err, `get("service"): constructor: could not create`)
 	})
 	t.Run("Errors in args", func(t *testing.T) {
 		s := container.NewService()
 		s.SetConstructor(
 			NewServer,
 			container.NewDependencyProvider(func() (any, error) {
-				return nil, errors.New("unexpected error")
+				return nil, errors.New("unexpected error 1")
 			}),
 			container.NewDependencyProvider(func() (any, error) {
-				return nil, errors.New("unexpected error")
+				return nil, errors.New("unexpected error 2")
 			}),
 		)
 
@@ -137,8 +137,8 @@ func TestContainer_createNewService(t *testing.T) {
 		c.OverrideService("server", s)
 
 		expected := []string{
-			`get("server"): constructor args: arg #0: cannot call provider func() (interface {}, error): unexpected error`,
-			`get("server"): constructor args: arg #1: cannot call provider func() (interface {}, error): unexpected error`,
+			`get("server"): constructor args: arg #0: unexpected error 1`,
+			`get("server"): constructor args: arg #1: unexpected error 2`,
 		}
 
 		svc, err := c.Get("server")
@@ -179,7 +179,7 @@ func TestContainer_setServiceFields(t *testing.T) {
 
 		expected := []string{
 			`get("service"): set field "Name": set (*interface {})."Name": field "Name" does not exist`,
-			`get("service"): field value "Age": cannot call provider func() (interface {}, error): unexpected error`,
+			`get("service"): field value "Age": unexpected error`,
 		}
 
 		svc, err := c.Get("service")
@@ -223,7 +223,7 @@ func TestContainer_Get_doNotCacheOnError(t *testing.T) {
 			ctx = container.ContextWithContainer(ctx, c)
 
 			five, err := c.GetInContext(ctx, "five")
-			assert.EqualError(t, err, `get("five"): constructor: cannot call provider func() (interface {}, error): my error`)
+			assert.EqualError(t, err, `get("five"): constructor: my error`)
 			assert.Nil(t, five)
 
 			// second invocation does not return error
@@ -326,7 +326,7 @@ func TestContainer_Get_errorInDecorator(t *testing.T) {
 	)
 
 	_, err := c.Get("service")
-	assert.EqualError(t, err, `get("service"): decorator #0: cannot call provider func(container.DecoratorPayload) (interface {}, error): my error`)
+	assert.EqualError(t, err, `get("service"): decorator #0: my error`)
 }
 
 type Server struct {

--- a/container/examples_test.go
+++ b/container/examples_test.go
@@ -373,8 +373,8 @@ func ExampleContainer_CircularDeps() {
 
 func ExampleContainer_Get_setter() {
 	riemannSvc := container.NewService()
-	riemannSvc.SetConstructor(func() *Person { // we have to use a pointer, because we use a setter
-		return &Person{}
+	riemannSvc.SetConstructor(func() Person { // we don't need to use a pointer here, even tho `SetName` requires a pointer receiver :)
+		return Person{}
 	})
 	riemannSvc.AppendCall("SetName", container.NewDependencyValue("Bernhard Riemann"))
 
@@ -384,7 +384,7 @@ func ExampleContainer_Get_setter() {
 	riemann, _ := c.Get("riemann")
 	fmt.Println(riemann)
 
-	// Output: &{Bernhard Riemann}
+	// Output: {Bernhard Riemann}
 }
 
 func ExampleContainer_Get_wither() {

--- a/internal/reflect/get_set.go
+++ b/internal/reflect/get_set.go
@@ -136,11 +136,11 @@ func Set(strct any, field string, val any, convert bool) (err error) {
 	*/
 	for {
 		switch {
-		case chain.prefixed(reflect.Ptr, reflect.Ptr):
+		case chain.Prefixed(reflect.Ptr, reflect.Ptr):
 			reflectVal = reflectVal.Elem()
 			chain = chain[1:]
 			continue
-		case chain.prefixed(reflect.Ptr, reflect.Interface, reflect.Ptr):
+		case chain.Prefixed(reflect.Ptr, reflect.Interface, reflect.Ptr):
 			reflectVal = reflectVal.Elem().Elem()
 			chain = chain[2:]
 			continue
@@ -214,7 +214,7 @@ func (c kindChain) equalTo(kinds ...reflect.Kind) bool {
 	return true
 }
 
-func (c kindChain) prefixed(kinds ...reflect.Kind) bool {
+func (c kindChain) Prefixed(kinds ...reflect.Kind) bool {
 	if len(c) < len(kinds) {
 		return false
 	}


### PR DESCRIPTION
- these methods are being used now by `*container.Container`
- changed error messages in `caller`