### PR TITLE
perf: decrease allocs

### DIFF
--- a/caller/caller.go
+++ b/caller/caller.go
@@ -78,7 +78,11 @@ func CallProvider(provider any, args []any, convertArgs bool) (_ any, err error)
 		return nil, err
 	}
 
-	results, err := caller.ValidateAndCallFunc(fn, args, convertArgs, caller.ValidateProvider)
+	if err := caller.ValidateProvider.Validate(fn); err != nil {
+		return nil, err
+	}
+
+	results, err := caller.CallFunc(fn, args, convertArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/caller/internal/caller/call.go
+++ b/caller/internal/caller/call.go
@@ -51,8 +51,10 @@ func (t reflectType) In(i int) reflect.Type {
 //
 // fn.Kind() MUST BE equal to [reflect.Func]
 func ValidateAndCallFunc(fn reflect.Value, args []any, convertArgs bool, v FuncValidator) ([]any, error) {
-	if err := v.Validate(fn); err != nil {
-		return nil, err
+	if v != nil {
+		if err := v.Validate(fn); err != nil {
+			return nil, err
+		}
 	}
 	return CallFunc(fn, args, convertArgs)
 }

--- a/caller/internal/caller/call.go
+++ b/caller/internal/caller/call.go
@@ -143,13 +143,11 @@ func ValidateAndForceCallByName(object any, method string, args []any, convertAr
 			return nil, err
 		}
 
-		return func() (res []any, err error) {
-			res, err = ValidateAndCallFunc(fn, args, convertArgs, v)
-			if err == nil {
-				val.Elem().Set(cp.Elem())
-			}
-			return
-		}()
+		res, err := ValidateAndCallFunc(fn, args, convertArgs, v)
+		if err == nil {
+			val.Elem().Set(cp.Elem())
+		}
+		return res, err
 	}
 
 	panic("ValidateAndForceCallByName: unexpected error") // this should be unreachable

--- a/caller/internal/caller/validators.go
+++ b/caller/internal/caller/validators.go
@@ -26,9 +26,9 @@ import (
 )
 
 var (
-	DontValidate     = ChainValidator{}
-	ValidateWither   = ChainValidator{validateWither}
-	ValidateProvider = ChainValidator{validateProvider}
+	DontValidate     FuncValidator = nil
+	ValidateWither                 = ChainValidator{validateWither}
+	ValidateProvider               = ChainValidator{validateProvider}
 )
 
 var (

--- a/container/container.go
+++ b/container/container.go
@@ -125,13 +125,18 @@ func (c *Container) CircularDeps() error {
 }
 
 func (c *Container) resolveDeps(contextualBag keyValue, deps ...Dependency) ([]any, error) {
+	if len(deps) == 0 {
+		return nil, nil
+	}
 	r := make([]any, len(deps))
-	errs := make([]error, len(deps))
+	var errs []error
 
 	for i, d := range deps {
 		var err error
 		r[i], err = c.resolveDep(contextualBag, d)
-		errs[i] = grouperror.Prefix(fmt.Sprintf("arg #%d: ", i), err)
+		if err != nil {
+			errs = append(errs, grouperror.Prefix(fmt.Sprintf("arg #%d: ", i), err))
+		}
 	}
 
 	return r, grouperror.Join(errs...)
@@ -162,7 +167,5 @@ func (c *Container) invalidateGraph() {
 }
 
 func (c *Container) warmUpGraph() {
-	c.onceWarmUp.Do(func() {
-		c.graphBuilder.warmUp()
-	})
+	c.onceWarmUp.Do(c.graphBuilder.warmUp)
 }

--- a/container/container_services_test.go
+++ b/container/container_services_test.go
@@ -57,12 +57,26 @@ func TestContainer_GetTaggedBy(t *testing.T) {
 			Name string
 		}{})
 		p.SetField("Name", container.NewDependencyParam("name"))
+		p.SetField("Age", container.NewDependencyValue(30))
 		p.Tag("person", 0)
+
+		p2 := container.NewService()
+		p2.SetValue(struct {
+			Name string
+		}{})
+		p2.SetField("Name", container.NewDependencyParam("name"))
+		p2.Tag("person", 0)
 
 		c := container.New()
 		c.OverrideService("jane", p)
+		c.OverrideService("john", p2)
 		_, err := c.GetTaggedBy("person")
-		assert.EqualError(t, err, `getTaggedBy("person"): get("jane"): field value "Name": getParam("name"): param does not exist`)
+		expected := []string{
+			`getTaggedBy("person"): get("jane"): field value "Name": getParam("name"): param does not exist`,
+			`getTaggedBy("person"): get("jane"): set field "Age": set (*interface {})."Age": field "Age" does not exist`,
+			`getTaggedBy("person"): get("john"): field value "Name": getParam("name"): param does not exist`,
+		}
+		assertErr.EqualErrorGroup(t, err, expected)
 	})
 }
 

--- a/internal/reflect/get_set.go
+++ b/internal/reflect/get_set.go
@@ -224,6 +224,7 @@ func (c kindChain) Prefixed(kinds ...reflect.Kind) bool {
 
 func ValueToKindChain(v reflect.Value) (kindChain, error) {
 	var r kindChain
+	r = make(kindChain, 0, 5)
 	ptrs := make(map[uintptr]struct{})
 	for {
 		if v.Kind() == reflect.Ptr && !v.IsNil() {


### PR DESCRIPTION
**before**

```
BenchmarkContainer_scopeDefault-4                      	 6346165	       184.7 ns/op	     112 B/op	       4 allocs/op
BenchmarkContainer_scopeShared-4                       	 6631849	       179.8 ns/op	     112 B/op	       4 allocs/op
BenchmarkContainer_scopeContextual-4                   	  395386	      3094 ns/op	     896 B/op	      30 allocs/op
BenchmarkContainer_scopeContextualSetField-4           	  685257	      1489 ns/op	     624 B/op	      18 allocs/op
BenchmarkContainer_scopeContextual_in_same_context-4   	10513569	       111.5 ns/op	      16 B/op	       1 allocs/op
BenchmarkContainer_scopeNonShared-4                    	  376460	      2668 ns/op	     608 B/op	      29 allocs/op
BenchmarkContainer_map-4                               	296526640	         4.033 ns/op	       0 B/op	       0 allocs/op
```

**after**

```
BenchmarkContainer_scopeDefault-4                      	 6336008	       188.9 ns/op	     120 B/op	       4 allocs/op
BenchmarkContainer_scopeShared-4                       	 6434148	       189.8 ns/op	     120 B/op	       4 allocs/op
BenchmarkContainer_scopeContextual-4                   	  526902	      2114 ns/op	     760 B/op	      20 allocs/op
BenchmarkContainer_scopeContextualSetField-4           	  758175	      1355 ns/op	     584 B/op	      14 allocs/op
BenchmarkContainer_scopeContextual_in_same_context-4   	10349127	       114.0 ns/op	      24 B/op	       1 allocs/op
BenchmarkContainer_scopeNonShared-4                    	  572878	      1936 ns/op	     472 B/op	      19 allocs/op
BenchmarkContainer_map-4                               	283429525	         4.028 ns/op	       0 B/op	       0 allocs/op
```